### PR TITLE
Large file partial download, Dropbox model update.

### DIFF
--- a/DropNet/Client/Client.cs
+++ b/DropNet/Client/Client.cs
@@ -146,7 +146,7 @@ namespace DropNet
             {
                 response = _restClientContent.Execute<T>(request);
 
-                if (response.StatusCode != HttpStatusCode.OK)
+                if (response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.PartialContent)
                 {
                     throw new DropboxException(response);
                 }
@@ -171,7 +171,7 @@ namespace DropNet
             {
                 response = _restClientContent.Execute(request);
 
-                if (response.StatusCode != HttpStatusCode.OK)
+				if (response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.PartialContent)
                 {
                     throw new DropboxException(response);
                 }
@@ -213,7 +213,7 @@ namespace DropNet
             {
                 _restClientContent.ExecuteAsync(request, (response, asynchandle) =>
                 {
-                    if (response.StatusCode != HttpStatusCode.OK)
+					if (response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.PartialContent)
                     {
                         failure(new DropboxException(response));
                     }
@@ -257,7 +257,7 @@ namespace DropNet
             {
                 _restClientContent.ExecuteAsync<T>(request, (response, asynchandle) =>
                 {
-                    if (response.StatusCode != HttpStatusCode.OK)
+					if (response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.PartialContent)
                     {
                         failure(new DropboxException(response));
                     }

--- a/DropNet/Client/Files.Async.cs
+++ b/DropNet/Client/Files.Async.cs
@@ -90,6 +90,24 @@ namespace DropNet
             ExecuteAsync(ApiType.Content, request, success, failure);
         }
 
+		/// <summary>
+		/// Downloads a part of a File from dropbox given the path
+		/// </summary>
+		/// <param name="path">The path of the file to download</param>
+		/// <param name="startByte">The index of the first byte to get.</param>
+		/// <param name="endByte">The index of the last byte to get.</param>
+		/// <param name="rev">Revision of the file</param>
+		/// <param name="success">Success callback </param>
+		/// <param name="failure">Failure callback </param>
+		public void GetFileAsync(string path, long startByte, long endByte, string rev, Action<IRestResponse> success, Action<DropboxException> failure)
+		{
+			if (!path.StartsWith("/")) path = "/" + path;
+
+			var request = _requestHelper.CreateGetFileRequest(path, Root, startByte, endByte, rev);
+
+			ExecuteAsync(ApiType.Content, request, success, failure);
+		}
+
 #if !WINDOWS_PHONE && !MONOTOUCH
         /// <summary>
         /// Uploads a File to Dropbox from the local file system to the specified folder

--- a/DropNet/Client/Files.Sync.cs
+++ b/DropNet/Client/Files.Sync.cs
@@ -76,6 +76,28 @@ namespace DropNet
             return response.RawBytes;
         }
 
+		//TODO - Make class for this to return (instead of just a byte[])
+		/// <summary>
+		/// Downloads a part of a File from dropbox given the path and a revision token.
+		/// </summary>
+		/// <param name="path">The path of the file to download</param>
+		/// <param name="startByte">The index of the first byte to get.</param>
+		/// <param name="endByte">The index of the last byte to get.</param>
+		/// <param name="rev">Revision string as featured by <code>MetaData.Rev</code></param>
+		/// <returns>The files raw bytes between <paramref name="startByte"/> and <paramref name="endByte"/>.</returns>
+		public byte[] GetFile(string path, long startByte, long endByte, string rev)
+		{
+			if (!path.StartsWith("/"))
+			{
+				path = "/" + path;
+			}
+
+			var request = _requestHelper.CreateGetFileRequest(path, Root, startByte, endByte, rev);
+			var response = Execute(ApiType.Content, request);
+
+			return response.RawBytes;
+		}
+
         /// <summary>
         /// Retrieve the content of a file in the local file system
         /// </summary>

--- a/DropNet/Helpers/RequestHelper.cs
+++ b/DropNet/Helpers/RequestHelper.cs
@@ -61,6 +61,19 @@ namespace DropNet.Helpers
             return request;
         }
 
+		public RestRequest CreateGetFileRequest(string path, string root, long startByte, long endByte, string rev)
+		{
+			var request = new RestRequest(Method.GET);
+			request.Resource = "{version}/files/{root}{path}";
+			request.AddParameter("version", _version, ParameterType.UrlSegment);
+			request.AddParameter("path", path, ParameterType.UrlSegment);
+			request.AddParameter("root", root, ParameterType.UrlSegment);
+			request.AddParameter("rev", rev, ParameterType.UrlSegment);
+			request.AddHeader("Range", "bytes=" + startByte + "-" + endByte);
+
+			return request;
+		}
+
 		public RestRequest CreateUploadFileRequest(string path, string filename, byte[] fileData, string root)
 		{
 			var request = new RestRequest(Method.POST);

--- a/DropNet/Models/MetaData.cs
+++ b/DropNet/Models/MetaData.cs
@@ -16,6 +16,7 @@ namespace DropNet.Models
         public string Root { get; set; }
         public string Icon { get; set; }
         public int Revision { get; set; }
+		public string Rev { get; set; }
         public List<MetaData> Contents { get; set; }
 
         public DateTime ModifiedDate


### PR DESCRIPTION
- Fixed issue 37: Downloading large file (using /files HTTP Range API)
- Added property “string Rev” to MetaData (Revision is deprecated).
