### PR TITLE
Escape the URL parameters in BuildAuthorizeUrl.

### DIFF
--- a/DropNet/Client/Client.cs
+++ b/DropNet/Client/Client.cs
@@ -125,8 +125,8 @@ namespace DropNet
             }
 
             //Go 1-Liner!
-            return string.Format("https://www.dropbox.com/1/oauth/authorize?oauth_token={0}{1}", userLogin.Token,
-                (string.IsNullOrEmpty(callback) ? string.Empty : "&oauth_callback=" + callback));
+            return string.Format("https://www.dropbox.com/1/oauth/authorize?oauth_token={0}{1}", userLogin.Token.UrlEncode(),
+                (string.IsNullOrEmpty(callback) ? string.Empty : "&oauth_callback=" + callback.UrlEncode()));
         }
 
 #if !WINDOWS_PHONE && !WINRT


### PR DESCRIPTION
In particular this means that the callback URL passed in to this function
and DropNetClient.GetTokenAndBuildUrl will be correctly escaped.
