### PR TITLE
Added chunked upload auto retry on chunk failure

### DIFF
--- a/DropNet/Client/Files.Async.cs
+++ b/DropNet/Client/Files.Async.cs
@@ -182,9 +182,10 @@ namespace DropNet
         /// <param name="overwrite">Specify wether the file upload should replace an existing file</param>
         /// <param name="parentRevision">The revision of the file you're editing</param>
         /// <param name="fileSize">The total size of the file if available</param>
-        public void UploadChunkedFileAsync(Func<long, byte[]> chunkNeeded, string path, Action<MetaData> success, Action<DropboxException> failure, Action<ChunkedUploadProgress> progress = null, bool overwrite = true, string parentRevision = null, long? fileSize = null)
+        /// <param name="maxRetries">The number of times to retry uploading if a chunk fails, unlimited if null.</param>
+        public void UploadChunkedFileAsync(Func<long, byte[]> chunkNeeded, string path, Action<MetaData> success, Action<DropboxException> failure, Action<ChunkedUploadProgress> progress = null, bool overwrite = true, string parentRevision = null, long? fileSize = null, long? maxRetries = null)
         {
-            var chunkedUploader = new DropNet.Helpers.ChunkedUploadHelper(this, chunkNeeded, path, success, failure, progress, overwrite, parentRevision, fileSize);
+            var chunkedUploader = new DropNet.Helpers.ChunkedUploadHelper(this, chunkNeeded, path, success, failure, progress, overwrite, parentRevision, fileSize, maxRetries);
             chunkedUploader.Start();
         }
 

--- a/DropNet/Helpers/ChunkedUploadHelper.cs
+++ b/DropNet/Helpers/ChunkedUploadHelper.cs
@@ -6,6 +6,7 @@ namespace DropNet.Helpers
 {
     public class ChunkedUploadHelper
     {
+        private const long DefaultMaxRetries = 100;
         private readonly DropNetClient _client;
         private readonly Func<long, byte[]> _chunkNeeded;
         private readonly string _path;
@@ -15,9 +16,12 @@ namespace DropNet.Helpers
         private readonly bool _overwrite;
         private readonly string _parentRevision;
         private readonly long? _fileSize;
+        private readonly long? _maxRetries;
         private long _chunksCompleted;
+        private long _chunksFailed;
+        private ChunkedUpload _lastChunkUploaded;
 
-        public ChunkedUploadHelper(DropNetClient client, Func<long, byte[]> chunkNeeded, string path, Action<MetaData> success, Action<DropboxException> failure, Action<ChunkedUploadProgress> progress, bool overwrite, string parentRevision, long? fileSize)
+        public ChunkedUploadHelper(DropNetClient client, Func<long, byte[]> chunkNeeded, string path, Action<MetaData> success, Action<DropboxException> failure, Action<ChunkedUploadProgress> progress, bool overwrite, string parentRevision, long? fileSize, long? maxRetries)
         {
             if (client == null)
             {
@@ -48,6 +52,7 @@ namespace DropNet.Helpers
             _overwrite = overwrite;
             _parentRevision = parentRevision;
             _fileSize = fileSize;
+            _maxRetries = maxRetries;
         }
 
         public void Start()
@@ -67,13 +72,14 @@ namespace DropNet.Helpers
         {
             if (_progress != null)
             {
-                _progress.Invoke(new ChunkedUploadProgress(uploadId, _chunksCompleted, offset, _fileSize));
+                _progress.Invoke(new ChunkedUploadProgress(uploadId, _chunksCompleted, offset, _chunksFailed, _fileSize));
             }
         }
 
         private void OnChunkSuccess(ChunkedUpload chunkedUpload)
         {
             _chunksCompleted++;
+            _lastChunkUploaded = chunkedUpload;
             UpdateProgress(chunkedUpload.Offset, chunkedUpload.UploadId);
             var offset = chunkedUpload.Offset;
             var nextChunk = _fileSize.GetValueOrDefault(long.MaxValue) > offset
@@ -93,7 +99,15 @@ namespace DropNet.Helpers
 
         private void OnChunkedUploadFailure(DropboxException dropboxException)
         {
-            _failure.Invoke(dropboxException);
+            _chunksFailed++;
+            if (_lastChunkUploaded != null && _chunksFailed <= _maxRetries.GetValueOrDefault(DefaultMaxRetries))
+            {
+                OnChunkSuccess(_lastChunkUploaded);
+            }
+            else
+            {
+                _failure.Invoke(dropboxException);
+            }
         }
     }
 }

--- a/DropNet/Models/ChunkedUploadProgress.cs
+++ b/DropNet/Models/ChunkedUploadProgress.cs
@@ -8,14 +8,16 @@ namespace DropNet.Models
         private readonly string _uploadId;
         private readonly long _chunksCompleted;
         private readonly long _bytesSaved;
+        private readonly long _retryCount;
         private readonly long? _fileSize;
 
-        public ChunkedUploadProgress(string uploadId, long chunksCompleted, long bytesSaved, long? fileSize)
+        public ChunkedUploadProgress(string uploadId, long chunksCompleted, long bytesSaved, long retryCount, long? fileSize)
         {
             _uploadId = uploadId;
-            this._chunksCompleted = chunksCompleted;
-            this._bytesSaved = bytesSaved;
-            this._fileSize = fileSize;
+            _chunksCompleted = chunksCompleted;
+            _bytesSaved = bytesSaved;
+            _retryCount = retryCount;
+            _fileSize = fileSize;
         }
 
         public string UploadId
@@ -47,6 +49,14 @@ namespace DropNet.Models
             get
             {
                 return this._fileSize;
+            }
+        }
+
+        public long RetryCount
+        {
+            get
+            {
+                return this._retryCount;
             }
         }
     }


### PR DESCRIPTION
A default retry limit of 100 is used for now. It is per upload and not
per chunk. The retry count was added to the progress information so that
it can be displayed to users if desired. Some sort of sliding delay
between retries might be a good idea so that the limit isn't burned
through too quickly in certain situations (disconnect ethernet cable,
airplaine mode, etc.).
