### PR TITLE
Improvements to DropboxException.

### DIFF
--- a/DropNet/Client/Client.cs
+++ b/DropNet/Client/Client.cs
@@ -178,7 +178,7 @@ namespace DropNet
 
                 if (response.StatusCode != HttpStatusCode.OK)
                 {
-                    throw new DropboxException(response);
+                    throw new DropboxRestException(response, HttpStatusCode.OK);
                 }
             }
             else
@@ -187,7 +187,7 @@ namespace DropNet
 
                 if (response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.PartialContent)
                 {
-                    throw new DropboxException(response);
+                    throw new DropboxRestException(response, HttpStatusCode.OK, HttpStatusCode.PartialContent);
                 }
             }
 
@@ -203,7 +203,7 @@ namespace DropNet
 
                 if (response.StatusCode != HttpStatusCode.OK)
                 {
-                    throw new DropboxException(response);
+                    throw new DropboxRestException(response, HttpStatusCode.OK);
                 }
             }
             else
@@ -212,7 +212,7 @@ namespace DropNet
 
                 if (response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.PartialContent)
                 {
-                    throw new DropboxException(response);
+                    throw new DropboxRestException(response, HttpStatusCode.OK, HttpStatusCode.PartialContent);
                 }
             }
 
@@ -240,7 +240,7 @@ namespace DropNet
                 {
                     if (response.StatusCode != HttpStatusCode.OK)
                     {
-                        failure(new DropboxException(response));
+                        failure(new DropboxRestException(response, HttpStatusCode.OK));
                     }
                     else
                     {
@@ -254,7 +254,7 @@ namespace DropNet
                 {
                     if (response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.PartialContent)
                     {
-                        failure(new DropboxException(response));
+                        failure(new DropboxRestException(response, HttpStatusCode.OK, HttpStatusCode.PartialContent));
                     }
                     else
                     {
@@ -284,7 +284,7 @@ namespace DropNet
                 {
                     if (response.StatusCode != HttpStatusCode.OK)
                     {
-                        failure(new DropboxException(response));
+                        failure(new DropboxRestException(response, HttpStatusCode.OK));
                     }
                     else
                     {
@@ -298,7 +298,7 @@ namespace DropNet
                 {
                     if (response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.PartialContent)
                     {
-                        failure(new DropboxException(response));
+                        failure(new DropboxRestException(response, HttpStatusCode.OK, HttpStatusCode.PartialContent));
                     }
                     else
                     {

--- a/DropNet/Exceptions/DropboxException.cs
+++ b/DropNet/Exceptions/DropboxException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using RestSharp;
 using System.Net;
 
@@ -6,27 +7,64 @@ namespace DropNet.Exceptions
 {
     public class DropboxException : Exception
     {
-        public HttpStatusCode StatusCode { get; set; }
+        public DropboxException()
+        {
+            
+        }
+
+        public DropboxException(string message) : base(message)
+        {
+        }
+    }
+
+    public class DropboxRestException : DropboxException
+    {
+        /// <summary>
+        /// Returned status code from the request
+        /// </summary>
+        public HttpStatusCode StatusCode { get; private set; }
+		
+        /// <summary>
+        /// Expected status codes to have seen instead of the one recieved. 
+        /// </summary>
+        public HttpStatusCode[] ExpectedCodes { get; private set; }
+		
         /// <summary>
         /// The response of the error call (for Debugging use)
         /// </summary>
         public IRestResponse Response { get; private set; }
-
-        public DropboxException()
+        
+        public DropboxRestException(string message) : base(message)
         {
         }
 
-        public DropboxException(string message)
-            : base(message)
-        {
-
-        }
-
-        public DropboxException(IRestResponse r)
+        /// <summary>
+        /// Creates a DropboxRestException with the rest response which caused the exception, and the status codes which were expected. 
+        /// </summary>
+        /// <param name="r">Rest Response which was not expected.</param>
+        /// <param name="expectedCodes">The expected status codes which were not found.</param>
+        public DropboxRestException(IRestResponse r, params HttpStatusCode[] expectedCodes)  
         {
             Response = r;
-            StatusCode = r.StatusCode;
+			StatusCode = r.StatusCode;
+            ExpectedCodes = expectedCodes;
         }
 
+        /// <summary>
+        /// Overridden message for Dropbox Exception. 
+        /// <returns>
+        /// The exception message in the format of "Received Response [{0}] : Expected to see [{1}]. The HTTP response was [{2}].
+        /// </returns>
+        /// </summary>
+	    public override string Message
+	    {
+		    get
+		    {
+			    return string.Format("Received Response [{0}] : Expected to see [{1}]. The HTTP response was [{2}].",
+                    Response.StatusCode,
+                    string.Join(", ", ExpectedCodes.Select(code => Enum.GetName(typeof(HttpStatusCode), code))),
+                    Response.Content);
+		    }
+	    }        
     }
 }

--- a/DropNet/Extensions/RestClientExtensions.cs
+++ b/DropNet/Extensions/RestClientExtensions.cs
@@ -42,7 +42,7 @@ namespace DropNet.Extensions
                                                      {
                                                          if (response.StatusCode != HttpStatusCode.OK)
                                                          {
-                                                             tcs.SetException(new DropboxException(response));
+                                                             tcs.SetException(new DropboxRestException(response, HttpStatusCode.OK));
                                                          }
                                                          else
                                                          {
@@ -86,7 +86,7 @@ namespace DropNet.Extensions
                                                      {
                                                          if (response.StatusCode != HttpStatusCode.OK)
                                                          {
-                                                             tcs.SetException(new DropboxException(response));
+                                                             tcs.SetException(new DropboxRestException(response, HttpStatusCode.OK));
                                                          }
                                                          else
                                                          {


### PR DESCRIPTION
Split out the base Exception class and added descendant DropboxRestException. Also update message returned by DropboxRestException to have more information as to what caused the exception. This will break on compile as DropboxException does not have StatusCode or Response properties.