### PR TITLE
Fixing problem with non-serializable UserLogin class

### DIFF
--- a/DropNet/Models/UserLogin.cs
+++ b/DropNet/Models/UserLogin.cs
@@ -1,5 +1,7 @@
-﻿namespace DropNet.Models
+﻿using System;
+namespace DropNet.Models
 {
+    [Serializable]
     public class UserLogin
     {
         public string Token { get; set; }


### PR DESCRIPTION
When using a different type of Session State, other than InProc, the class needs to be serializable.
