### PR TITLE
Add Team information to AccountInfo

### DIFF
--- a/DropNet/Models/AccountInfo.cs
+++ b/DropNet/Models/AccountInfo.cs
@@ -8,6 +8,7 @@
         public string display_name { get; set; }
         public QuotaInfo quota_info { get; set; }
         public long uid { get; set; }
+        public Team team { get; set; }
     }
 
     public class QuotaInfo
@@ -15,5 +16,10 @@
         public long shared { get; set; }
         public long quota { get; set; }
         public long normal { get; set; }
+    }
+
+    public class Team
+    {
+        public string name { get; set; }
     }
 }


### PR DESCRIPTION
Dropbox API has been updated to include Dropbox Team information for Dropbox for Business accounts.
