### PR TITLE
Added Client_Mtime property to MetaData class

### DIFF
--- a/DropNet/Models/MetaData.cs
+++ b/DropNet/Models/MetaData.cs
@@ -24,8 +24,7 @@ namespace DropNet.Models
         {
             get
             {
-                //cast to datetime and return
-                return Modified == null ? DateTime.MinValue : DateTime.Parse(Modified); //RFC1123 format date codes are returned by API
+                return GetDateTimeFromString(Modified);
             }
         }
 
@@ -33,16 +32,11 @@ namespace DropNet.Models
         {
             get
             {
-                string str = Modified;
-                if (str == null)
-                    return DateTime.MinValue;
-                if (str.EndsWith(" +0000")) str = str.Substring(0, str.Length - 6);
-                if (!str.EndsWith(" UTC")) str += " UTC";
-                return DateTime.ParseExact(str, "ddd, d MMM yyyy HH:mm:ss UTC", System.Globalization.CultureInfo.InvariantCulture);
+                return GetUTCDateTimeFromString(Modified);
             }
             set
             {
-                Modified = value.ToString("ddd, d MMM yyyy HH:mm:ss UTC");
+                Modified = GetStringFromDateTime(value);
             }
         }
 
@@ -50,8 +44,7 @@ namespace DropNet.Models
         {
             get
             {
-                //cast to datetime and return
-                return Client_Mtime == null ? DateTime.MinValue : DateTime.Parse(Client_Mtime); //RFC1123 format date codes are returned by API
+                return GetDateTimeFromString(Client_Mtime);
             }
         }
 
@@ -59,19 +52,14 @@ namespace DropNet.Models
         {
             get
             {
-                string str = Client_Mtime;
-                if (str == null)
-                    return DateTime.MinValue;
-                if (str.EndsWith(" +0000")) str = str.Substring(0, str.Length - 6);
-                if (!str.EndsWith(" UTC")) str += " UTC";
-                return DateTime.ParseExact(str, "ddd, d MMM yyyy HH:mm:ss UTC", System.Globalization.CultureInfo.InvariantCulture);
+                return GetUTCDateTimeFromString(Client_Mtime);
             }
             set
             {
-                Client_Mtime = value.ToString("ddd, d MMM yyyy HH:mm:ss UTC");
+                Client_Mtime = GetStringFromDateTime(value);
             }
         }
-		
+
         public string Name
         {
             get
@@ -106,6 +94,27 @@ namespace DropNet.Models
 
                 return Is_Dir ? string.Empty : Path.Substring(Path.LastIndexOf("."));
             }
+        }
+
+        private static DateTime GetDateTimeFromString(string dateTimeStr)
+        {
+            //cast to datetime and return
+            return dateTimeStr == null ? DateTime.MinValue : DateTime.Parse(dateTimeStr); //RFC1123 format date codes are returned by API
+        }
+
+        private static DateTime GetUTCDateTimeFromString(string dateTimeStr)
+        {
+            string str = dateTimeStr;
+            if (str == null)
+                return DateTime.MinValue;
+            if (str.EndsWith(" +0000")) str = str.Substring(0, str.Length - 6);
+            if (!str.EndsWith(" UTC")) str += " UTC";
+            return DateTime.ParseExact(str, "ddd, d MMM yyyy HH:mm:ss UTC", System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        private static string GetStringFromDateTime(DateTime dateTime)
+        {
+            return dateTime.ToString("ddd, d MMM yyyy HH:mm:ss UTC");
         }
     }
 


### PR DESCRIPTION
Added support for the "client_mtime" field in Dropbox API (I don't know since when it exists though).

Added properties:
1. string Client_Mtime
2. DateTime Client_MtimeDate
3. DateTime UTCDateClient_Mtime

For 2 and 3, I moved the code out from ModifiedDate and UTCDateModified and created separate private static methods so that both Modified and Client_Mtime could use the same code.

I'm doing the pull request for the first time, but I hope I'm doing it correctly.

Thanks!
