### PR TITLE
DropboxException: better message generation

### DIFF
--- a/DropNet/Exceptions/DropboxException.cs
+++ b/DropNet/Exceptions/DropboxException.cs
@@ -11,21 +11,28 @@ namespace DropNet.Exceptions
         /// The response of the error call (for Debugging use)
         /// </summary>
         public IRestResponse Response { get; private set; }
+        private string message;
+        override public string Message { get { return message; } }
 
         public DropboxException()
         {
         }
 
         public DropboxException(string message)
-            : base(message)
         {
-
+            this.message = message;
         }
 
         public DropboxException(IRestResponse r)
         {
             Response = r;
             StatusCode = r.StatusCode;
+            if(r.ContentType == "application/json") {
+                message = r.StatusCode.ToString();
+                RestSharp.JsonObject parsedJson = SimpleJson.DeserializeObject(r.Content) as RestSharp.JsonObject;
+                if (parsedJson != null && parsedJson.ContainsKey("error") && parsedJson["error"] != null)
+                    message += ": " + parsedJson["error"].ToString();
+            }
         }
 
     }


### PR DESCRIPTION
Simple extension to DropboxException to be slightly more informative about what went wrong in case a Rest failure occured.
