### PR TITLE
Fixed URL for OAuth2 login, and added token disable support

### DIFF
--- a/DropNet/Client/Client.cs
+++ b/DropNet/Client/Client.cs
@@ -14,6 +14,7 @@ namespace DropNet
 {
     public partial class DropNetClient
     {
+        private const string MainServerBaseUrl = "https://www.dropbox.com";
         private const string ApiBaseUrl = "https://api.dropbox.com";
         private const string ApiContentBaseUrl = "https://api-content.dropbox.com";
         private const string ApiNotifyUrl = "https://api-notify.dropbox.com";
@@ -58,6 +59,7 @@ namespace DropNet
         private readonly string _appsecret;
         private readonly AuthenticationMethod _authenticationMethod;
 
+        private RestClient _restClientMainServer;
         private RestClient _restClient;
         private RestClient _restClientContent;
         private RestClient _restClientNotify;
@@ -166,6 +168,12 @@ namespace DropNet
 
         private void LoadClient()
         {
+            _restClientMainServer = new RestClient(MainServerBaseUrl);
+
+#if !WINDOWS_PHONE && !WINRT
+            _restClientMainServer.Proxy = _proxy;
+#endif
+
             _restClient = new RestClient(ApiBaseUrl);
 
 #if !WINDOWS_PHONE && !WINRT
@@ -239,7 +247,7 @@ namespace DropNet
                 throw new ArgumentNullException("redirectUri");
             }
             RestRequest request = _requestHelper.BuildOAuth2AuthorizeUrl(oAuth2AuthorizationFlow, _apiKey, redirectUri, state);
-            return _restClient.BuildUri(request).ToString();
+            return _restClientMainServer.BuildUri(request).ToString();
         }
 
 #if !WINDOWS_PHONE && !WINRT

--- a/DropNet/Client/User.Async.cs
+++ b/DropNet/Client/User.Async.cs
@@ -69,6 +69,15 @@ namespace DropNet
             ExecuteAsync(ApiType.Base, request, success, failure);
         }
 
+        /// <summary>
+        /// Disables the current access token.
+        /// </summary>
+        public void DisableAccessTokenAsync(Action success, Action<DropboxException> failure)
+        {
+            var request = _requestHelper.CreateDisableAccessTokenRequest();
+            ExecuteAsync(ApiType.Base, request, _ => success(), failure);
+        }
+
         [Obsolete("No longer supported by Dropbox")]
         public void CreateAccountAsync(string email, string firstName, string lastName, string password, Action<RestResponse> success, Action<DropboxException> failure)
         {

--- a/DropNet/Client/User.Sync.cs
+++ b/DropNet/Client/User.Sync.cs
@@ -67,6 +67,15 @@ namespace DropNet
             return Execute<AccountInfo>(ApiType.Base, request);
         }
 
+        /// <summary>
+        /// Disables the current access token.
+        /// </summary>
+        public IRestResponse DisableAccessToken()
+        {
+            var request = _requestHelper.CreateDisableAccessTokenRequest();
+            return Execute(ApiType.Base, request);
+        }
+
     }
 }
 #endif

--- a/DropNet/Helpers/RequestHelper.cs
+++ b/DropNet/Helpers/RequestHelper.cs
@@ -386,6 +386,13 @@ namespace DropNet.Helpers
             return request;
         }
 
+        public RestRequest CreateDisableAccessTokenRequest()
+        {
+            var request = new RestRequest("{version}/disable_access_token", Method.POST);
+            request.AddParameter("version", _version, ParameterType.UrlSegment);
+            return request;
+        }
+
         public RestRequest CreateAccountInfoRequest()
         {
             var request = new RestRequest(Method.GET);


### PR DESCRIPTION
This change fixes the OAuth2 overload of `BuildAuthorizeUrl` to use www.dropbox.com as the base URL instead of api.dropbox.com, per the API docs. It did not seem to work using api.dropbox.com, although I'm very new at this and might have been doing something wrong. At any rate the change makes the code match the Dropbox API docs. I also added support for the `disable_access_token` API function.

This is my first ever GitHub pull request so please let me know if I'm doing it wrong or missing out on etiquette. I believe I matched the style of the existing code, at the very least.