### PR TITLE
Unified MetaData methods, added optional parameters 'hash', 'list' and 'include_deleted'.

### DIFF
--- a/DropNet.Tests/FileSyncTests.cs
+++ b/DropNet.Tests/FileSyncTests.cs
@@ -25,7 +25,7 @@ namespace DropNet.Tests
         [TestMethod]
         public void Can_Get_MetaData_With_Special_Char()
         {
-            var fileInfo = _client.GetMetaData("/Test/Getting'Started.rtf");
+            var fileInfo = _client.GetMetaData("/Test/Getting'Started.rtf", null);
 
             Assert.IsNotNull(fileInfo);
         }
@@ -169,7 +169,7 @@ namespace DropNet.Tests
         [TestMethod]
         public void Can_Get_MetaData()
         {
-            var metaData = _client.GetMetaData("/Public");
+            var metaData = _client.GetMetaData("/Public", null);
 
             Assert.IsNotNull(metaData);
             Assert.IsNotNull(metaData.Contents);

--- a/DropNet.Tests/FileTaskTests.cs
+++ b/DropNet.Tests/FileTaskTests.cs
@@ -25,7 +25,7 @@ namespace DropNet.Tests
         public void Task_Get_MetaData()
         {
             var path = "/Test";
-            var metaTask = _client.GetMetaDataTask(path);
+            var metaTask = _client.GetMetaDataTask(path, null);
 
             metaTask.Wait();
 
@@ -38,7 +38,7 @@ namespace DropNet.Tests
         public void Task_Get_MetaData_With_Special_Char()
         {
             var path = "/Test/Getting'Started.rtf";
-            var metaTask = _client.GetMetaDataTask(path);
+            var metaTask = _client.GetMetaDataTask(path, null);
 
             metaTask.Wait();
 

--- a/DropNet.Tests/FileTests1.Sandbox.cs
+++ b/DropNet.Tests/FileTests1.Sandbox.cs
@@ -29,7 +29,7 @@ namespace DropNet.Tests
         [TestMethod]
         public void SANDBOX_Can_Get_MetaData_With_Special_Char()
         {
-            var fileInfo = _client.GetMetaData("/test'.txt");
+            var fileInfo = _client.GetMetaData("/test'.txt", null);
             
             Assert.IsNotNull(fileInfo);
         }
@@ -163,7 +163,7 @@ namespace DropNet.Tests
         [TestMethod]
         public void SANDBOX_Can_Get_MetaData()
         {
-            var metaData = _client.GetMetaData("/");
+            var metaData = _client.GetMetaData("/", null);
 
             Assert.IsNotNull(metaData);
             Assert.IsNotNull(metaData.Contents);

--- a/DropNet.Tests/Helpers/RequestHelperTest.cs
+++ b/DropNet.Tests/Helpers/RequestHelperTest.cs
@@ -198,7 +198,7 @@ namespace DropNet.Tests
         public void CreateMetadataRequestTest()
         {
             string path = fixture.CreateAnonymous<string>();
-            RestRequest actual = _target.CreateMetadataRequest(path, "dropbox");
+            RestRequest actual = _target.CreateMetadataRequest(path, "dropbox", null, false, false);
 
             Assert.IsNotNull(actual);
             Assert.IsTrue(actual.Method == Method.GET);

--- a/DropNet/Client/Files.Async.cs
+++ b/DropNet/Client/Files.Async.cs
@@ -9,25 +9,16 @@ namespace DropNet
 {
     public partial class DropNetClient
     {
-        public void GetMetaDataAsync(string path, Action<MetaData> success, Action<DropboxException> failure)
+        public void GetMetaDataAsync(Action<MetaData> success, Action<DropboxException> failure, String hash = null, Boolean list = false, Boolean include_deleted = false)
         {
-            if (!string.IsNullOrEmpty(path) && !path.StartsWith("/"))
-            {
-                path = "/" + path;
-            }
-
-            var request = _requestHelper.CreateMetadataRequest(path, Root);
-
-            ExecuteAsync(ApiType.Base, request, success, failure);
+            GetMetaDataAsync(String.Empty, success, failure, hash, list, include_deleted);
         }
 
-        public void GetMetaDataAsync(string path, string hash, Action<MetaData> success, Action<DropboxException> failure)
+        public void GetMetaDataAsync(String path, Action<MetaData> success, Action<DropboxException> failure, String hash = null, Boolean list = false, Boolean include_deleted = false)
         {
             if (path != "" && !path.StartsWith("/")) path = "/" + path;
 
-            var request = _requestHelper.CreateMetadataRequest(path, Root);
-
-            request.AddParameter("hash", hash);
+            var request = _requestHelper.CreateMetadataRequest(path, Root, hash, list, include_deleted);
 
             ExecuteAsync(ApiType.Base, request, success, failure);
         }

--- a/DropNet/Client/Files.Sync.cs
+++ b/DropNet/Client/Files.Sync.cs
@@ -14,16 +14,16 @@ namespace DropNet
 {
     public partial class DropNetClient
     {
-        public MetaData GetMetaData()
+        public MetaData GetMetaData(String hash = null, Boolean list = false, Boolean include_deleted = false)
         {
-            return GetMetaData(string.Empty);
+            return GetMetaData(String.Empty, hash, list, include_deleted);
         }
 
-        public MetaData GetMetaData(string path)
+        public MetaData GetMetaData(String path, String hash = null, Boolean list = false, Boolean include_deleted = false)
         {
 			if (path != "" && !path.StartsWith("/")) path = "/" + path;
 
-            var request = _requestHelper.CreateMetadataRequest(path, Root);
+            var request = _requestHelper.CreateMetadataRequest(path, Root, hash, list, include_deleted);
 
             return Execute<MetaData>(ApiType.Base, request);
         }

--- a/DropNet/Client/Files.Task.cs
+++ b/DropNet/Client/Files.Task.cs
@@ -11,25 +11,16 @@ namespace DropNet
 {
     public partial class DropNetClient
     {
-        public Task<MetaData> GetMetaDataTask(string path)
+        public Task<MetaData> GetMetaDataTask(String hash, Boolean list = false, Boolean include_deleted = false)
         {
-            if (!string.IsNullOrEmpty(path) && !path.StartsWith("/"))
-            {
-                path = "/" + path;
-            }
-
-            var request = _requestHelper.CreateMetadataRequest(path, Root);
-
-            return ExecuteTask<MetaData>(ApiType.Base, request);
+            return GetMetaDataTask(String.Empty, hash, list, include_deleted);
         }
 
-        public Task<MetaData> GetMetaDataTask(string path, string hash)
+        public Task<MetaData> GetMetaDataTask(String path, String hash = null, Boolean list = false, Boolean include_deleted = false)
         {
             if (path != "" && !path.StartsWith("/")) path = "/" + path;
 
-            var request = _requestHelper.CreateMetadataRequest(path, Root);
-
-            request.AddParameter("hash", hash);
+            var request = _requestHelper.CreateMetadataRequest(path, Root, hash, list, include_deleted);
 
             return ExecuteTask<MetaData>(ApiType.Base, request);
         }

--- a/DropNet/Client/IDropNetClient.cs
+++ b/DropNet/Client/IDropNetClient.cs
@@ -51,23 +51,21 @@ namespace DropNet
         string BuildAuthorizeUrl(OAuth2AuthorizationFlow oAuth2AuthorizationFlow, string redirectUri, string state = null);
 
         /// <summary>
-        /// Gets MetaData for a File or Folder. For a folder this includes its contents. For a file, this includes details such as file size.
+        /// Gets MetaData for the root folder.
         /// </summary>
         /// <param name="path">The path of the file or folder</param>
         /// <param name="success">Success call back</param>
         /// <param name="failure">Failure call back </param>
-        void GetMetaDataAsync(string path, Action<MetaData> success, Action<DropboxException> failure);
+        void GetMetaDataAsync(Action<MetaData> success, Action<DropboxException> failure, String hash = null, Boolean list = false, Boolean include_deleted = false);
 
         /// <summary>
         /// Gets MetaData for a File or Folder. For a folder this includes its contents. For a file, this includes details such as file size.
-        /// Optional 'hash' param returns HTTP code 304	(Directory contents have not changed) if contents have not changed since the
-        /// hash was retrieved on a previous call.
         /// </summary>
         /// <param name="path">The path of the file or folder</param>
         /// <param name="hash">hash - Optional. Listing return values include a hash representing the state of the directory's contents. If you provide this argument to the metadata call, you give the service an opportunity to respond with a "304 Not Modified" status code instead of a full (potentially very large) directory listing. This argument is ignored if the specified path is associated with a file or if list=false.</param>
         /// <param name="success">Success callback </param>
         /// <param name="failure">Failure callback </param>
-        void GetMetaDataAsync(string path, string hash, Action<MetaData> success, Action<DropboxException> failure);
+        void GetMetaDataAsync(String path, Action<MetaData> success, Action<DropboxException> failure, String hash = null, Boolean list = false, Boolean include_deleted = false);
 
         /// <summary>
         /// Gets list of metadata for search string
@@ -326,8 +324,8 @@ namespace DropNet
         /// <param name="failure">Failure callback </param>
         void GetCopyRefAsync(string path, Action<CopyRefResponse> success, Action<DropboxException> failure);
 
-        Task<MetaData> GetMetaDataTask(string path);
-        Task<MetaData> GetMetaDataTask(string path, string hash);
+        Task<MetaData> GetMetaDataTask(String hash = null, Boolean list = false, Boolean include_deleted = false);
+        Task<MetaData> GetMetaDataTask(String path, String hash = null, Boolean list = false, Boolean include_deleted = false);
         Task<List<MetaData>> SearchTask(string searchString);
         Task<List<MetaData>> SearchTask(string searchString, int fileLimit);
         Task<List<MetaData>> SearchTask(string searchString, string path);
@@ -352,15 +350,21 @@ namespace DropNet
         /// <summary>
         /// Gets MetaData for the root folder.
         /// </summary>
+        /// <param name="hash">hash - Optional. Listing return values include a hash representing the state of the directory's contents. If you provide this argument to the metadata call, you give the service an opportunity to respond with a "304 Not Modified" status code instead of a full (potentially very large) directory listing. This argument is ignored if the specified path is associated with a file or if list=false.</param>
+        /// <param name="list">If true, the folder's metadata will include a contents field with a list of metadata entries for the contents of the folder. If false, the contents field will be omitted.</param>
+        /// <param name="include_deleted">Only applicable when list is set. If this parameter is set to true, then contents will include the metadata of deleted children. Note that the target of the metadata call is always returned even when it has been deleted (with is_deleted set to true) regardless of this flag.</param>
         /// <returns></returns>
-        MetaData GetMetaData();
+        MetaData GetMetaData(String hash = null, Boolean list = false, Boolean include_deleted = false);
 
         /// <summary>
         /// Gets MetaData for a File or Folder. For a folder this includes its contents. For a file, this includes details such as file size.
         /// </summary>
         /// <param name="path">The path of the file or folder</param>
+        /// <param name="hash">hash - Optional. Listing return values include a hash representing the state of the directory's contents. If you provide this argument to the metadata call, you give the service an opportunity to respond with a "304 Not Modified" status code instead of a full (potentially very large) directory listing. This argument is ignored if the specified path is associated with a file or if list=false.</param>
+        /// <param name="list">If true, the folder's metadata will include a contents field with a list of metadata entries for the contents of the folder. If false, the contents field will be omitted.</param>
+        /// <param name="include_deleted">Only applicable when list is set. If this parameter is set to true, then contents will include the metadata of deleted children. Note that the target of the metadata call is always returned even when it has been deleted (with is_deleted set to true) regardless of this flag.</param>
         /// <returns></returns>
-        MetaData GetMetaData(string path);
+        MetaData GetMetaData(String path, String hash = null, Boolean list = false, Boolean include_deleted = false);
 
         /// <summary>
         /// Gets List of MetaData for a File versions. Each metadata item contains info about file in certain version on Dropbox.

--- a/DropNet/Helpers/RequestHelper.cs
+++ b/DropNet/Helpers/RequestHelper.cs
@@ -18,13 +18,20 @@ namespace DropNet.Helpers
             _version = version;
         }
 
-        public RestRequest CreateMetadataRequest(string path, string root)
+        public RestRequest CreateMetadataRequest(String path, String root, String hash, Boolean list, Boolean include_deleted)
         {
             var request = new RestRequest(Method.GET);
             request.Resource = "{version}/metadata/{root}{path}";
             request.AddParameter("version", _version, ParameterType.UrlSegment);
             request.AddParameter("path", path, ParameterType.UrlSegment);
             request.AddParameter("root", root, ParameterType.UrlSegment);
+
+            if (list)
+            {
+                request.AddParameter("hash", hash);
+                request.AddParameter("list", list.ToString().ToLower());
+                request.AddParameter("include_deleted", include_deleted.ToString().ToLower());
+            }
 
             return request;
         }


### PR DESCRIPTION
There were some differences in method declarations for sync, async and task realizations. I think, all of them should have common declaration.
After some changes there are two types of calls for 'metadata' requests:
* method for getting metadata of root folder
* method for getting metadata of particular folder of file
Parameter hash from previous realizations was removed to optional parameter. Also added optional parameters 'list' and 'include_deleted' for issue #141.