### PR TITLE
Fix for performing chunked upload

### DIFF
--- a/DropNet/Helpers/RequestHelper.cs
+++ b/DropNet/Helpers/RequestHelper.cs
@@ -181,9 +181,7 @@ namespace DropNet.Helpers
         public RestRequest CreateChunkedUploadRequest(byte[] fileData)
         {
             var request = new RestRequest(Method.PUT);
-            request.Resource = "{version}/chunked_upload?oauth_consumer_key={oauth_consumer_key}&oauth_nonce={oauth_nonce}";
-            request.Resource += "&oauth_token={oauth_token}&oauth_timestamp={oauth_timestamp}";
-            request.Resource += "&oauth_signature={oauth_signature}&oauth_signature_method={oauth_signature_method}&oauth_version={oauth_version}";
+            request.Resource = "{version}/chunked_upload";
             request.AddParameter("version", _version, ParameterType.UrlSegment);
 
             request.AddParameter("file", fileData, ParameterType.RequestBody);
@@ -194,9 +192,7 @@ namespace DropNet.Helpers
         public RestRequest CreateAppendChunkedUploadRequest(ChunkedUpload upload, byte[] fileData)
         {
             var request = new RestRequest(Method.PUT);
-            request.Resource = "{version}/chunked_upload?upload_id={upload_id}&offset={offset}&oauth_consumer_key={oauth_consumer_key}&oauth_nonce={oauth_nonce}";
-            request.Resource += "&oauth_token={oauth_token}&oauth_timestamp={oauth_timestamp}";
-            request.Resource += "&oauth_signature={oauth_signature}&oauth_signature_method={oauth_signature_method}&oauth_version={oauth_version}";
+            request.Resource = "{version}/chunked_upload?upload_id={upload_id}&offset={offset}";
             request.AddParameter("version", _version, ParameterType.UrlSegment);
             request.AddParameter("upload_id", upload.UploadId, ParameterType.UrlSegment);
             request.AddParameter("offset", upload.Offset, ParameterType.UrlSegment);


### PR DESCRIPTION
I was trying to use the chunked upload using the StartChunkedUpload, AppendChunkedUpload, and CommitChunkedUpload methods, but it wasn't working. I wasn't getting an exception on the initial StartChunkedUpload call, but the ChunkUpload object coming back was empty, which eventually led to a null reference exception.

Using Fiddler, I looked at the request and found this call on the Create:

PUT /1/chunked_upload?oauth_consumer_key=%7Boauth_consumer_key%7D&oauth_nonce=%7Boauth_nonce%7D&oauth_token=%7Boauth_token%7D&oauth_timestamp=%7Boauth_timestamp%7D&oauth_signature=%7Boauth_signature%7D&oauth_signature_method=%7Boauth_signature_method%7D&oauth_version=%7Boauth_version%7D HTTP/1.1

which resulted in this response:

{"error": "Invalid app key (consumer key). Check your app's configuration to make sure everything is correct."}

I looked at the code and found that in both CreateChunkedUploadRequest and CreateAppendChunkedUploadRequest, several oauth parameters were being added to the request, but that they weren't being populated. It didn't look like these oauth parameters were present in other similar calls so I didn't think they were necessary. I ended up removing them and the chunked upload then worked.

On create, my request looked like this:

PUT /1/chunked_upload HTTP/1.1

And my response like this:

{"expires": "Wed, 18 May 2016 21:14:19 +0000", "upload_id": "AAAAAAAAAdGk8g0SdUJBLQ", "offset": 4194304}

I was then able to make an append request like this:

PUT /1/chunked_upload?upload_id=AAAAAAAAAdGk8g0SdUJBLQ&offset=4194304 HTTP/1.1
